### PR TITLE
Changed node for uninterrupted serial connection

### DIFF
--- a/arduino_firmware_io/arduino_firmware_io.ino
+++ b/arduino_firmware_io/arduino_firmware_io.ino
@@ -1,7 +1,7 @@
 /*
 lab-nanny Firmware
 
-Controller of the arduino that sends data from the inputs and performs actions depending
+Controller of the arduino DUE that sends data from the inputs and performs actions depending
 on the messages received.
 
 Analog input on the analog pins is read-in at a sampling rate of ~xyz kS/s
@@ -22,14 +22,28 @@ Adapted from James Keaveney's https://github.com/jameskeaveney/LiveArduinoData
 
 */
 
+
+//#define FASTADC 1
+
+// defines for setting and clearing register bits
+//#ifndef cbi
+//#define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
+//#endif
+//#ifndef sbi
+//#define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
+//#endif
+
+
 // set up variables
 const int buffer_length = 1; // length of data chunks sent at a time via SerialUSB
 
-const int sampling_time_sleep = 50; // in micros
+const int sampling_time_sleep = 100; // in micros
 unsigned long init_time = 0;
+
 int ledPin = 13;
 int maxDIPin = 14;
 int commandNumber =0;
+int current_time = 0;
 
 String strTime = "";
 String strOut = "";
@@ -45,56 +59,29 @@ String strC8 = "";
 String strC9 = "";
 String strC10 = "";
 String strC11 = "";
+String strC15 = "";
 
-/* To enable channels  (see page 1338 of datasheet) of the AX pins.
-See 1320 of datasheet for conversion ADXX->PAXX
-See also http://www.arduino.cc/en/Hacking/PinMappingSAM3X for the pin mapping 
-between Arduino names and SAM3X pin names
-*/
-                  
-const int A0_PIN  = 0b10000000;
-const int A1_PIN  = 0b1000000;
-const int A2_PIN  = 0b100000;
-const int A3_PIN  = 0b10000;
-const int A4_PIN  = 0b1000;
-const int A5_PIN  = 0b100;
-const int A6_PIN  = 0b10;
-const int A7_PIN  = 0b1;
-const int A8_PIN  = 0b10000000000;
-const int A9_PIN  = 0b100000000000;
-const int A10_PIN = 0b1000000000000;
-const int A11_PIN = 0b10000000000000;
-
-/* The PIN_MAP is a mask that specifices which analog channels to read. It can be
- * constructed as the sum of the different AX_PIN constants. */
-
-const int PIN_MAP = A0_PIN+A1_PIN+A2_PIN+A3_PIN+A4_PIN+A5_PIN+A6_PIN+A7_PIN;
-
- // There might be a problem if we "activate" a lot of the channels but they are not connected: 
- // the "floating" signal wiggles when the rest of the lines are changed.
-unsigned long current_time;
 
 void setup() {
-  
-  // set ADC resolution
-  analogReadResolution(12);
-  
-  // manually set registers for faster analog reading than the normal arduino methods
-  ADC->ADC_MR |= 0xC0; // set free running mode (page 1333 of the Sam3X datasheet)
-  ADC->ADC_CHER = PIN_MAP; 
-  ADC->ADC_CHDR = 0xFFFF-PIN_MAP; // disable all other channels
-  ADC->ADC_CR=2;        // begin ADC conversion
-  
-  
+  Serial.begin(115200); // baud rate is ignored for USB - always at 12 Mb/s
+  pinMode(13, OUTPUT);
+  digitalWrite(13,HIGH);
+
+//#if FASTADC
+// // set prescale to 16
+// sbi(ADCSRA,ADPS2) ;
+// cbi(ADCSRA,ADPS1) ;
+// cbi(ADCSRA,ADPS0) ;
+//#endif
+
   // initialise serial port
-  SerialUSB.begin(115200); // baud rate is ignored for USB - always at 12 Mb/s
-  while (!SerialUSB); // wait for USB serial port to be connected - wait for pc program to open the serial port
+  //while (!Serial); // wait for USB serial port to be connected - wait for pc program to open the serial port
   init_time =millis();
   pinMode(11, OUTPUT);
   pinMode(12, OUTPUT);
   pinMode(13, OUTPUT);
   pinMode(14, OUTPUT);
-
+  
 
 }
 
@@ -105,23 +92,23 @@ void loop() {
   // data acquisition will start with a synchronisation step:
   // python should send a single byte of data, the arduino will send one back to sync timeouts
   int incoming = 0;
-  if (SerialUSB.available() > 0) // polls whether anything is ready on the read buffer - nothing happens until there's something there
+  if (Serial.available() > 0) // polls whether anything is ready on the read buffer - nothing happens until there's something there
   {
-    incoming = SerialUSB.read();
+    incoming = Serial.read();
     // after data received, send the same back
     // if abs(incoming)<maxDIPin  (14 in this case)
     commandNumber = incoming-65;
     if (abs(commandNumber)<=maxDIPin){
       if (commandNumber>=0){
         digitalWrite(abs(commandNumber),HIGH);
-            SerialUSB.println(abs(commandNumber));
+            Serial.println(abs(commandNumber));
       }   // Can be done faster toggling if PIND used
       else{
         digitalWrite(abs(commandNumber)-1,LOW); 
-        SerialUSB.println(abs(commandNumber)-1);
+        Serial.println(abs(commandNumber)-1);
       }
     }
-    else{SerialUSB.println(incoming);
+    else{Serial.println(incoming);
     }
     
     
@@ -135,56 +122,44 @@ void loop() {
     for (int jj = 0; jj < buffer_length; jj++)
     {
       
-      // ADC acquisition
-      
-      // can put this in a small loop for some averaging if required - takes ~ 60 microsec per read/concatenate cycle
-      while((ADC->ADC_ISR & 0x80)!=0x80); // wait for conversion to complete - see page 1345 of datasheet     
+        
       // concatenate strings
       current_time = millis()-init_time;
       strTime.concat(current_time); // time axis
       strTime.concat(',');     
-      strC0.concat(ADC->ADC_CDR[7]); // read data from the channel data register
+      strC0.concat(analogRead(0)); // read data from the channel data register
       strC0.concat(',');
-      strC1.concat(ADC->ADC_CDR[6]); // read data from the channel data register
-      strC1.concat(',');
-      strC2.concat(ADC->ADC_CDR[5]); // read data from the channel data register
-      strC2.concat(',');
-      strC3.concat(ADC->ADC_CDR[4]); // read data from the channel data register
-      strC3.concat(',');
-      strC4.concat(ADC->ADC_CDR[3]); // read data from the channel data register
-      strC4.concat(',');
-      strC5.concat(ADC->ADC_CDR[2]); // read data from the channel data register
-      strC5.concat(',');
-      strC6.concat(ADC->ADC_CDR[1]); // read data from the channel data register
-      strC6.concat(',');
-      strC7.concat(ADC->ADC_CDR[0]); // read data from the channel data register
-      strC7.concat(',');
+      strC0.concat(analogRead(1)); // read data from the channel data register
+      strC0.concat(',');
+      strC0.concat(analogRead(2)); // read data from the channel data register
+      strC0.concat(',');
+      strC0.concat(analogRead(3)); // read data from the channel data register
+      strC0.concat(',');
+      strC0.concat(analogRead(4)); // read data from the channel data register
+      strC0.concat(',');
+      strC0.concat(analogRead(5)); // read data from the channel data register
+      strC0.concat(',');
+      strC0.concat(analogRead(6)); // read data from the channel data register
+      strC0.concat(',');
+      strC0.concat(analogRead(7)); // read data from the channel data register
+      strC0.concat(',');
       
       //Serial.print(current_time);
       //Serial.print(",");
       
-      delayMicroseconds(sampling_time_sleep); // limit sampling rate to something reasonable - a few kS/s
+      //delayMicroseconds(sampling_time_sleep); // limit sampling rate to something reasonable - a few kS/s
     }      
     // send data via SerialUSB
     // perform a flush first to wait for the previous buffer to be sent, before overwriting it
-    SerialUSB.flush();
-    strOut = strTime + strC0 + strC1 + strC2 + strC3 + strC4 + strC5 + strC6 + strC7; 
-    SerialUSB.print(strOut); // doesn't wait for write to complete before moving on
+    Serial.flush();
+    strOut = strTime + strC0 ; 
+    Serial.print(strOut); // doesn't wait for write to complete before moving on
     
     // clear string data - re-initialise
     strTime = "";
     strC0 = "";
-    strC1 = "";
-    strC2 = "";
-    strC3 = "";
-    strC4 = "";
-    strC5 = "";
-    strC6 = "";
-    strC7 = "";
-    strC8 = "";
-    strC9 = "";
     // finally, print end-of-data and end-of-line character to signify no more data will be coming
-    SerialUSB.println("\0");
+    Serial.println("\0");
     
   }
 }

--- a/clients/datavis-master.html
+++ b/clients/datavis-master.html
@@ -94,11 +94,11 @@ var x = d3.scaleLinear()
     .domain([0, n - 1])
     .range([0, width-margin.right-margin.left]);
 var y = d3.scaleLinear()
-    .domain([0, 3.3])
+    .domain([0, 5])
     .range([height-margin.top-margin.bottom, 0]);
 
 var y_temp = d3.scaleLinear()
-    .domain([20, 26])
+    .domain([10, 26])
     .range([height-margin.top-margin.bottom, 0]);
 
 var line = d3.line()

--- a/servers/server_master.py
+++ b/servers/server_master.py
@@ -12,6 +12,7 @@ import tornado.web
 from tornado.websocket import WebSocketClosedError
 import sqlite3
 from sqlite3 import OperationalError
+import argparse
 import time
 from database.DBHandler import DBHandler as DBHandler
 
@@ -26,8 +27,8 @@ CLIENT_SOCKETNAME = r'/client_ws'
 
 DEFAULTMESSAGE    = 'X,50,0'
 DEFAULTDBNAME     = 'example.db'
-PERIODICITY       = 75
-DB_PERIODICITY    = 10000   #Save data to db every...
+PERIODICITY       = 100
+DB_PERIODICITY    = 30000   #Save data to db every...
 
 class MasterServer(object):
     """ Class that runs the Master Server for lab-nanny.
@@ -47,7 +48,7 @@ class MasterServer(object):
                  client_socketname=CLIENT_SOCKETNAME,
                  periodicity=PERIODICITY,
                  db_periodicity = DB_PERIODICITY,
-                 verbose = False):
+                 verbose = True):
         #Init parameters
         self.socket_port             = socket_port
         self.slave_socketname        = slave_socketname
@@ -344,10 +345,18 @@ def broadcast(list_of_endpoints, msg):
 
 
 
-def main1():
-    my_master_server = MasterServer()
+def main1(periodicity=100, verbose=0):
+    my_master_server = MasterServer(periodicity=periodicity,
+                                    verbose=verbose)
 
 
 if __name__ == "__main__":
-    main1()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-pr","--periodicity",help="address of the master server websocket",
+                        type=int,default=100)
+    parser.add_argument("-v","--verbose",help="Activate verbose",
+                        type=int,default=0)
+    args = parser.parse_args()
 
+    main1(periodicity=args.periodicity,
+          verbose=args.verbose)


### PR DESCRIPTION
To accomodate the genuino Mega, I changed the code in the firmware, which (for some still-unexplained reason) took about 1 second to initialize the serial communications everytime the arduino had to connect.

Under the previous architecture this was unacceptable, since every message from the master server triggered a new serial connection- which was, in any case, quite suboptimal.

Now I have changed the node to initialize the serial connection upon starting the node, and just keep track and restart the connection when necessary.